### PR TITLE
Update deprecated command fire method for Laravel 5.5

### DIFF
--- a/src/Console/QueueClearCommand.php
+++ b/src/Console/QueueClearCommand.php
@@ -67,7 +67,7 @@ class QueueClearCommand extends Command {
 	 *
 	 * @return void
 	 */
-	public function fire()
+	public function handle()
 	{
 		$connection = $this->argument('connection') ?: $this->config->get('queue.default');
 		$queue = $this->argument('queue') ?: $this->config->get('queue.connections.' . $connection  . '.queue');


### PR DESCRIPTION
Right now this package doesn't work in Laravel 5.5 because the `fire` method for commands was removed in favor of `handle` (see: https://laravel.com/docs/5.1/upgrade). IIRC `fire` was deprecated back in 5.1 so this change should work for any Laravel version >= 5.1 💯  